### PR TITLE
[DEV-254944] Implementing a listener to handle the in-app browser closure in the alternative OAuth flow for the demo bank.

### DIFF
--- a/ios/TrustlyReactNativeExample/AppDelegate.mm
+++ b/ios/TrustlyReactNativeExample/AppDelegate.mm
@@ -2,6 +2,9 @@
 
 #import <React/RCTBundleURLProvider.h>
 
+#import <React/RCTLinkingManager.h>
+
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -12,6 +15,13 @@
   self.initialProps = @{};
 
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
+}
+
+
+- (BOOL)application:(UIApplication *)application
+            openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+    return [RCTLinkingManager application:application openURL:url options:options];
 }
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,9 @@ const ResultScreen = ({ title, returnParameters, onBackToWidget }) => (
 );
 
 export default class App extends Component {
-  trustlyWebView = null;
+
+  trustlyWebView: WebView | null = null;
+  deepLinkEventListener: any = null;
 
   // Initialize payment data
   establishData: EstablishData = {
@@ -75,9 +77,18 @@ export default class App extends Component {
     returnParameters: '',
   };
 
-  constructor(props) {
-    super(props);
+  componentDidMount() {
+    this.deepLinkEventListener = Linking.addEventListener('url', this.handleDeepLink);
   }
+
+  componentWillUnmount() {
+    this.deepLinkEventListener.remove() 
+  }
+
+  // Handle the deep link URL here
+  handleDeepLink = () => {
+    InAppBrowser.closeAuth(); // Close the InAppBrowser when a deep link is detected
+  };
 
   // Open the provided URL in InAppBrowser or default browser if not available
   async openLink(url: string) {
@@ -155,9 +166,7 @@ export default class App extends Component {
 
   // Handle the OAuth result
   handleOAuthResult = (result: any) => {
-    if (result.type === 'success') {
-      this.trustlyWebView.injectJavaScript('window.Trustly.proceedToChooseAccount();'); // Proceed with the transaction
-    }
+    this.trustlyWebView.injectJavaScript('window.Trustly.proceedToChooseAccount();'); // Proceed with the transaction
   };
 
   // Update the amount when the user inputs a new value


### PR DESCRIPTION
### Description

To ensure the in-app browser closes in the alternative OAuth flow of the demo bank, add the following code to the `AppDelegate.mm` in the iOS project:

```
#import <React/RCTLinkingManager.h>

- (BOOL)application:(UIApplication *)application
            openURL:(NSURL *)url
            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
    return [RCTLinkingManager application:application openURL:url options:options];
}
```

At the end of the alternative flow, Trustly will call the URL Scheme provided by the merchant via the establish data, and the code above will capture this URL Scheme call and forward it to the React interface.

In the React code, the example code below should be added to capture the URL Scheme call and consequently close the in-app browser.

```
import {  Linking } from "react-native";

componentDidMount() {
  this.deepLinkEventListener = Linking.addEventListener('url', this.handleDeepLink);
}

componentWillUnmount() {
  this.deepLinkEventListener.remove() 
}

// Handle the deep link URL here
handleDeepLink = () => {
  InAppBrowser.closeAuth(); // Close the InAppBrowser when a deep link is detected
};
```

> **Note:**  We recommend running this example app at least once to understand how a transaction works through the OAuth flow.  This code serves as an example of the logic to be followed for the proper functioning of the OAuth flow. Each merchant should consider their application's unique aspects when implementing it.

---

### Requirements

- [ ] Changes were properly tested (attach evidence if applicable)
- [ ] Repository's code-style/linting compliant

---

### Evidence

_ Not applicable

---

### Additional Information

_Not applicable
